### PR TITLE
Issue #81 keep fundingTokens in Seed contract

### DIFF
--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -256,13 +256,7 @@ contract Seed {
       * @dev                     Close distribution.
     */
     function close() public onlyAdmin protected {
-        // transfer all the tokens back to admin
-        /*
-        require(
-            fundingToken.transfer(admin, fundingToken.balanceOf(address(this))),
-            "Seed: should transfer funding tokens to admin"
-        );
-        */
+        // transfer seed tokens back to admin
         require(
             seedToken.transfer(admin, seedToken.balanceOf(address(this))),
             "Seed: should transfer seed tokens to admin"

--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -217,7 +217,8 @@ contract Seed {
     /**
       * @dev         Returns funding tokens to user.
     */
-    function retrieveFundingTokens() public protected beforeMinimumReached {
+    function retrieveFundingTokens() public beforeMinimumReached {
+        require(paused != true, "Seed: should not be paused");
         require(tokenLocks[msg.sender].fundingAmount > 0, "Seed: zero funding amount");
         Lock storage tokenLock = tokenLocks[msg.sender];
         uint amount = tokenLock.fundingAmount;
@@ -256,10 +257,12 @@ contract Seed {
     */
     function close() public onlyAdmin protected {
         // transfer all the tokens back to admin
+        /*
         require(
             fundingToken.transfer(admin, fundingToken.balanceOf(address(this))),
             "Seed: should transfer funding tokens to admin"
         );
+        */
         require(
             seedToken.transfer(admin, seedToken.balanceOf(address(this))),
             "Seed: should transfer seed tokens to admin"

--- a/test/seed.js
+++ b/test/seed.js
@@ -235,10 +235,8 @@ contract('Seed', (accounts) => {
                         isWhitelisted,
                         fee
                     );
-                    // Also changed the below staatement, so that on buy() the limit does not exceeds
                     await seedToken.transfer(setup.data.seed.address, (new BN(cap,10)).div(new BN(price,10)).mul(new BN(pct_base,10)), {from:setup.root});
                     await fundingToken.approve(setup.data.seed.address, (new BN(smallBuyAmount,10)).mul(new BN(price,10)).div(new BN(pct_base,10)), {from:buyer2});
-                    // the buyer buys seed token here, to test retrieveFundingTokens()
                     await setup.data.seed.buy(toWei('900'), {from:buyer2});
                 });
                 it('can only be called by admin', async () => {
@@ -252,13 +250,10 @@ contract('Seed', (accounts) => {
                     await setup.data.seed.close({from:admin});
                     expect((await seedToken.balanceOf(admin)).toString()).to.equal(stBalance.toString());
                 });
-                // Added two test.
-                // Checks if the funding tokens are still in the contract
                 it('donot transfer funding tokens to the admin', async () => {
                     let ftBalance = await fundingToken.balanceOf(setup.data.seed.address);
                     expect((await fundingToken.balanceOf(setup.data.seed.address)).toString()).to.equal(ftBalance.toString());
                 });
-                // Checks if the buyer can retrieve token back even the contract is closed
                 it('returns funding tokens to buyer', async () => {
                     expect((await fundingToken.balanceOf(buyer2)).toString()).to.equal('0');
 

--- a/test/seed.js
+++ b/test/seed.js
@@ -235,8 +235,11 @@ contract('Seed', (accounts) => {
                         isWhitelisted,
                         fee
                     );
-                    await fundingToken.transfer(buyer2, smallBuyAmount, {from:setup.root});
-                    await fundingToken.approve(setup.data.seed.address, smallBuyAmount, {from:buyer2});
+                    // Also changed the below staatement, so that on buy() the limit does not exceeds
+                    await seedToken.transfer(setup.data.seed.address, (new BN(cap,10)).div(new BN(price,10)).mul(new BN(pct_base,10)), {from:setup.root});
+                    await fundingToken.approve(setup.data.seed.address, (new BN(smallBuyAmount,10)).mul(new BN(price,10)).div(new BN(pct_base,10)), {from:buyer2});
+                    // the buyer buys seed token here, to test retrieveFundingTokens()
+                    await setup.data.seed.buy(toWei('900'), {from:buyer2});
                 });
                 it('can only be called by admin', async () => {
                     await expectRevert(
@@ -244,12 +247,27 @@ contract('Seed', (accounts) => {
                         "Seed: caller should be admin"
                     );
                 });
-                it('transfers all tokens to the admin', async () => {
-                    let ftBalance = await fundingToken.balanceOf(setup.data.seed.address);
+                it('transfers seed tokens to the admin', async () => {
                     let stBalance = await seedToken.balanceOf(setup.data.seed.address);
                     await setup.data.seed.close({from:admin});
-                    expect((await fundingToken.balanceOf(admin)).toString()).to.equal(ftBalance.toString());
                     expect((await seedToken.balanceOf(admin)).toString()).to.equal(stBalance.toString());
+                });
+                // Added two test.
+                // Checks if the funding tokens are still in the contract
+                it('donot transfer funding tokens to the admin', async () => {
+                    let ftBalance = await fundingToken.balanceOf(setup.data.seed.address);
+                    expect((await fundingToken.balanceOf(setup.data.seed.address)).toString()).to.equal(ftBalance.toString());
+                });
+                // Checks if the buyer can retrieve token back even the contract is closed
+                it('returns funding tokens to buyer', async () => {
+                    expect((await fundingToken.balanceOf(buyer2)).toString()).to.equal('0');
+
+                    let tx = await setup.data.seed.retrieveFundingTokens({from:buyer2});
+                    setup.data.tx = tx;
+
+                    expectEvent.inTransaction(setup.data.tx.tx, setup.data.seed, 'FundingReclaimed');
+                    expect((await fundingToken.balanceOf(buyer2)).toString()).to
+                        .equal(((new BN(smallBuyAmount,10)).mul(new BN(price,10)).div(new BN(pct_base,10))).toString());
                 });
             });
         });


### PR DESCRIPTION
For Issue #81 
Updated at Seed.sol
1) Updated close() function to prevent admin to take all fundingToken.
2) Updated retrieveFundingToken() to enable users to claim fundingTtokens even after the Seed is closed.
 Updated at Seed.js
1)Added test - funding tokens still in contract
2) Added test - Buyer can retrieve tokens after token close.