### PR TITLE
Issue #79  - Tokens locks are overwritten

### DIFF
--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -190,8 +190,20 @@ contract Seed {
             minimumReached = true;
         }
 
-        uint _lockTokens = tokenLocks[msg.sender].seedAmount;
-        _addLock(msg.sender, _seedAmount, (_lockTokens.add(fundingAmount)), feeAmount);
+        uint _prevSeedAmount = tokenLocks[msg.sender].seedAmount;
+        uint _prevFundingAmount = tokenLocks[msg.sender].fundingAmount;
+        uint16 _prevDaysClaimed = tokenLocks[msg.sender].daysClaimed;
+        uint _prevTotalClaimed = tokenLocks[msg.sender].totalClaimed;
+        uint _prevFee = tokenLocks[msg.sender].fee;
+
+        _addLock(
+            msg.sender,
+            (_prevSeedAmount.add(_seedAmount)),
+            (_prevFundingAmount.add(fundingAmount)),
+            _prevDaysClaimed,
+            _prevTotalClaimed,
+            (_prevFee.add(feeAmount))
+            );
     }
 
     /**
@@ -349,6 +361,8 @@ contract Seed {
         address _recipient,
         uint256 _seedAmount,
         uint256 _fundingAmount,
+        uint16 _daysClaimed,
+        uint256 _totalClaimed,
         uint256 _fee
     )
     internal
@@ -359,8 +373,8 @@ contract Seed {
 
         Lock memory lock = Lock({
             seedAmount: _seedAmount,
-            daysClaimed: 0,
-            totalClaimed: 0,
+            daysClaimed: _daysClaimed,
+            totalClaimed: _totalClaimed,
             fundingAmount: _fundingAmount,
             fee: _fee
             });

--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -166,9 +166,7 @@ contract Seed {
         //  lockedSeedFee is an amount of fee we already need to pay in seedTokens
         uint lockedSeedFee = (alreadyLockedSeedTokens.mul(uint(PPM))).mul(fee).div(PPM100);
 
-        // We are that overall supply of fundingToken that will be in the end of this function execution
-        // will be less then maximum cap
-        // balanceToBe = currentBalance + amountOfFundTokenToExchange + amountOfFundTokenToPayForFee
+        // total fundingAmount should not be greater than the hardCap
         require( (fundingToken.balanceOf(address(this)).
                   add(fundingAmount).
                   add((feeAmount.mul(price)).div(PCT_BASE))) <= cap,
@@ -190,19 +188,12 @@ contract Seed {
             minimumReached = true;
         }
 
-        uint _prevSeedAmount = tokenLocks[msg.sender].seedAmount;
-        uint _prevFundingAmount = tokenLocks[msg.sender].fundingAmount;
-        uint16 _prevDaysClaimed = tokenLocks[msg.sender].daysClaimed;
-        uint _prevTotalClaimed = tokenLocks[msg.sender].totalClaimed;
-        uint _prevFee = tokenLocks[msg.sender].fee;
-
         _addLock(
             msg.sender,
-            (_prevSeedAmount.add(_seedAmount)),
-            (_prevFundingAmount.add(fundingAmount)),
-            _prevDaysClaimed,
-            _prevTotalClaimed,
-            (_prevFee.add(feeAmount))
+            (tokenLocks[msg.sender].seedAmount.add(_seedAmount)),       // Previous Seed Amount + new seed amount
+            (tokenLocks[msg.sender].fundingAmount.add(fundingAmount)),  // Previous Funding Amount + new funding amount
+            tokenLocks[msg.sender].totalClaimed,
+            (tokenLocks[msg.sender].fee.add(feeAmount))                 // Previous Fee + new fee
             );
     }
 

--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -192,6 +192,7 @@ contract Seed {
             msg.sender,
             (tokenLocks[msg.sender].seedAmount.add(_seedAmount)),       // Previous Seed Amount + new seed amount
             (tokenLocks[msg.sender].fundingAmount.add(fundingAmount)),  // Previous Funding Amount + new funding amount
+            tokenLocks[msg.sender].daysClaimed,
             tokenLocks[msg.sender].totalClaimed,
             (tokenLocks[msg.sender].fee.add(feeAmount))                 // Previous Fee + new fee
             );


### PR DESCRIPTION
Resolves #79 
Resolves #89 
Updates:-
1) Now buy() calls _addLock() with updated Lock values.
2) Added test 'updates lock when it buys tokens'
3) Adapted multiple tests to user calling buy() twice.
4) Corrected calculations for ```seedToken``` amount at ```SeedFactory.sol```.