### PR TITLE
Updated how we store metadata

### DIFF
--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -44,7 +44,7 @@ contract Seed {
     IERC20  public fundingToken;
     uint8   public fee;
 
-    bytes32 public metadata;           // IPFS Hash
+    bytes   public metadata;           // IPFS Hash
 
     uint256 constant internal PCT_BASE        = 10 ** 18;  // // 0% = 0; 1% = 10 ** 16; 100% = 10 ** 18
 
@@ -69,7 +69,7 @@ contract Seed {
     event SeedsPurchased(address indexed recipient, uint256 amountPurchased);
     event TokensClaimed(address indexed recipient,uint256 amount,address indexed beneficiary,uint256 feeAmount);
     event FundingReclaimed(address indexed recipient, uint256 amountReclaimed);
-    event MetadataUpdated(bytes32 indexed metadata);
+    event MetadataUpdated(bytes indexed metadata);
 
     struct FunderPortfolio { 
         uint256 seedAmount;
@@ -376,7 +376,7 @@ contract Seed {
       * @dev                     Updates metadata.
       * @param _metadata         Seed contract metadata, that is IPFS Hash
     */
-    function updateMetadata(bytes32 _metadata) public {
+    function updateMetadata(bytes memory _metadata) public {
         require(
             initialized != true || msg.sender == admin,
             "Seed: contract should not be initialized or caller should be admin"

--- a/contracts/seed/SeedFactory.sol
+++ b/contracts/seed/SeedFactory.sol
@@ -71,7 +71,7 @@ contract SeedFactory is CloneFactory, Ownable {
         uint32 _vestingCliff,
         bool _permissionedSeed,
         uint8 _fee,
-        bytes32 _metadata
+        bytes memory _metadata
     ) public onlyOwner returns (address) {
         require(masterCopy != Seed(0), "SeedFactory: mastercopy cannot be zero address");
         // deploy clone

--- a/test/seed-factory.js
+++ b/test/seed-factory.js
@@ -6,7 +6,7 @@ const { constants, time, expectRevert, expectEvent } = require("@openzeppelin/te
 const helpers = require("./helpers");
 const { BN } = require("@openzeppelin/test-helpers/src/setup");
 const Seed = artifacts.require("Seed");
-const { toWei } = web3.utils;
+const { toWei, toHex } = web3.utils;
 
 const deploy = async (accounts) => {
     // initialize test setup
@@ -72,7 +72,7 @@ contract("SeedFactory", (accounts) => {
             vestingCliff = await time.duration.days(90); // 3 months
             isWhitelisted = false;
             fee = 2;
-            metadata = `0x`;
+            metadata = toHex('QmRCtyCWKnJTtTCy1RTXte8pY8vV58SU8YtAC9oa24C4Qg');
 
             seedFactory = setup.seedFactory;
         });


### PR DESCRIPTION
converted bytes32 -> bytes type.
As the length of ipfs hash is > bytes32.